### PR TITLE
Revert "Bump golang from 1.17.7-alpine to 1.18.0-alpine"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.0-alpine as build
+FROM golang:1.17.7-alpine as build
 
 WORKDIR /go/src/
 


### PR DESCRIPTION
Reverts obukhov/redis-inventory#41