### PR TITLE
feat(scanner): use multiple consumers

### DIFF
--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -2,6 +2,9 @@ package scanner
 
 import (
 	"context"
+	"fmt"
+	"runtime"
+	"sync"
 
 	"github.com/obukhov/redis-inventory/src/adapter"
 	"github.com/obukhov/redis-inventory/src/trie"
@@ -39,22 +42,38 @@ func (s *RedisScanner) Scan(options adapter.ScanOptions, result *trie.Trie) {
 	}
 
 	s.scanProgress.Start(totalCount)
-	for key := range s.redisService.ScanKeys(context.Background(), options) {
-		s.scanProgress.Increment()
-		res, err := s.redisService.GetMemoryUsage(context.Background(), key)
-		if err != nil {
-			s.logger.Error().Err(err).Msgf("Error dumping key %s", key)
-			continue
-		}
 
-		result.Add(
-			key,
-			trie.ParamValue{Param: trie.BytesSize, Value: res},
-			trie.ParamValue{Param: trie.KeysCount, Value: 1},
-		)
+	cpus := runtime.NumCPU()
+	var wg sync.WaitGroup
+	wg.Add(cpus)
 
-		s.logger.Debug().Msgf("Dump %s value: %d", key, res)
+	fmt.Printf("batching start\n")
+	keys := s.redisService.ScanKeys(context.Background(), options)
+	for i := 0; i < cpus; i++ {
+		go func(batch int) {
+			defer wg.Done()
+
+			for key := range keys {
+				s.scanProgress.Increment()
+				res, err := s.redisService.GetMemoryUsage(context.Background(), key)
+				if err != nil {
+					s.logger.Error().Err(err).Msgf("Error dumping key %s", key)
+					return
+				}
+
+				result.Add(
+					key,
+					trie.ParamValue{Param: trie.BytesSize, Value: res},
+					trie.ParamValue{Param: trie.KeysCount, Value: 1},
+				)
+
+				s.logger.Debug().Msgf("Dump %s value: %d", key, res)
+			}
+		}(i)
 	}
+
+	wg.Wait()
+	fmt.Printf("batching end\n")
 	s.scanProgress.Stop()
 }
 

--- a/src/trie/aggregator.go
+++ b/src/trie/aggregator.go
@@ -1,5 +1,7 @@
 package trie
 
+import "sync"
+
 // ParamValue value for inventory param
 type ParamValue struct {
 	Param InvParam
@@ -15,16 +17,22 @@ func NewAggregator() *Aggregator {
 
 // Aggregator struct holding various inventory param values
 type Aggregator struct {
+	sync.RWMutex
 	Params map[InvParam]int64
 }
 
 // Add adds inv parameter value to aggregation
 func (a *Aggregator) Add(param InvParam, val int64) {
+	a.Lock()
 	a.Params[param] += val
+	a.Unlock()
 }
 
 // Clone creates a copy of aggregator
 func (a *Aggregator) Clone() *Aggregator {
+	a.RLock()
+	defer a.RUnlock()
+
 	cloned := NewAggregator()
 	for k, v := range a.Params {
 		cloned.Params[k] = v


### PR DESCRIPTION
- due to high network latency when connecting to hosted redis the
  scanner takes a long time as it runs on 1 core
- using multiple goroutines (count same as number of cpu's) helps
  improving the ETA