### PR TITLE
Add `--tls` option

### DIFF
--- a/cmd/app/index.go
+++ b/cmd/app/index.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"context"
-	"github.com/mediocregopher/radix/v4"
 	"github.com/obukhov/redis-inventory/src/adapter"
 	"github.com/obukhov/redis-inventory/src/logger"
 	"github.com/obukhov/redis-inventory/src/renderer"
@@ -21,7 +19,7 @@ var indexCmd = &cobra.Command{
 		consoleLogger := logger.NewConsoleLogger(logLevel)
 		consoleLogger.Info().Msg("Start indexing")
 
-		clientSource, err := (radix.PoolConfig{}).New(context.Background(), "tcp", args[0])
+		clientSource, err := newPool(args[0])
 		if err != nil {
 			consoleLogger.Fatal().Err(err).Msg("Can't create redis client")
 		}
@@ -67,4 +65,5 @@ func init() {
 	indexCmd.Flags().StringVarP(&pattern, "pattern", "k", "*", "Glob pattern limiting the keys to be aggregated")
 	indexCmd.Flags().IntVarP(&scanCount, "scanCount", "c", 1000, "Number of keys to be scanned in one iteration (argument of scan command)")
 	indexCmd.Flags().IntVarP(&throttleNs, "throttle", "t", 0, "Throttle: number of nanoseconds to sleep between keys")
+	indexCmd.Flags().BoolVar(&isTLS, "tls", false, "Use TLS connection")
 }

--- a/cmd/app/inventory.go
+++ b/cmd/app/inventory.go
@@ -1,10 +1,8 @@
 package app
 
 import (
-	"context"
 	"os"
 
-	"github.com/mediocregopher/radix/v4"
 	"github.com/obukhov/redis-inventory/src/adapter"
 	"github.com/obukhov/redis-inventory/src/logger"
 	"github.com/obukhov/redis-inventory/src/renderer"
@@ -22,7 +20,7 @@ var scanCmd = &cobra.Command{
 		consoleLogger := logger.NewConsoleLogger(logLevel)
 		consoleLogger.Info().Msg("Start scanning")
 
-		clientSource, err := (radix.PoolConfig{}).New(context.Background(), "tcp", args[0])
+		clientSource, err := newPool(args[0])
 		if err != nil {
 			consoleLogger.Fatal().Err(err).Msg("Can't create redis client")
 		}
@@ -67,4 +65,5 @@ func init() {
 	scanCmd.Flags().StringVarP(&pattern, "pattern", "k", "*", "Glob pattern limiting the keys to be aggregated")
 	scanCmd.Flags().IntVarP(&scanCount, "scanCount", "c", 1000, "Number of keys to be scanned in one iteration (argument of scan command)")
 	scanCmd.Flags().IntVarP(&throttleNs, "throttle", "t", 0, "Throttle: number of nanoseconds to sleep between keys")
+	scanCmd.Flags().BoolVar(&isTLS, "tls", false, "Use TLS connection")
 }

--- a/cmd/app/pool.go
+++ b/cmd/app/pool.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/mediocregopher/radix/v4"
+)
+
+func newPool(addr string) (radix.Client, error) {
+	pool := radix.PoolConfig{}
+	if isTLS {
+		pool.Dialer.NetDialer = &tls.Dialer{
+			NetDialer: nil,
+			Config:    nil,
+		}
+	}
+
+	return pool.New(context.Background(), "tcp", addr)
+}

--- a/cmd/app/vars.go
+++ b/cmd/app/vars.go
@@ -4,4 +4,5 @@ var (
 	output, outputParams, separators, pattern string
 	maxChildren, scanCount, throttleNs        int
 	logLevel                                  string
+	isTLS                                     bool
 )

--- a/docs/cobra/redis-inventory_index.md
+++ b/docs/cobra/redis-inventory_index.md
@@ -20,6 +20,7 @@ redis-inventory index redis://[:<password>@]<host>:<port>[/<dbIndex>] [flags]
   -c, --scanCount int       Number of keys to be scanned in one iteration (argument of scan command) (default 1000)
   -s, --separators string   Symbols that logically separate levels of the key (default ":")
   -t, --throttle int        Throttle: number of nanoseconds to sleep between keys
+      --tls                 Use TLS connection
 ```
 
 ### SEE ALSO

--- a/docs/cobra/redis-inventory_inventory.md
+++ b/docs/cobra/redis-inventory_inventory.md
@@ -22,6 +22,7 @@ redis-inventory inventory redis://[:<password>@]<host>:<port>[/<dbIndex>] [flags
   -c, --scanCount int          Number of keys to be scanned in one iteration (argument of scan command) (default 1000)
   -s, --separators string      Symbols that logically separate levels of the key (default ":")
   -t, --throttle int           Throttle: number of nanoseconds to sleep between keys
+      --tls                    Use TLS connection
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
This PR lets redis-inventory be used with redis servers that support only SSL-based connections.

The implementation is the same as in https://github.com/obukhov/redis-inventory/pull/69, but without the changes not related to adding the `--tls` option.